### PR TITLE
Force Chief::Command result to be a Chief::Result object

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,25 @@ You can use destructuring assignment to easily grab the value and the errors.
 result, value, errors = ExampleApplication::SomeExternalService::Notify.call(message)
 ```
 
+## Things to consider
+
+* A `Chief::Command` must call `success!` or `fail!`. We think this leads to better code so we enforce it.
+
+```ruby
+irb(main):001:0> class ExampleCommand < Chief::Command
+irb(main):002:1>   def call
+irb(main):003:2>     nil
+irb(main):004:2>   end
+irb(main):005:1> end
+=> :call
+irb(main):006:0> ExampleCommand.call
+RuntimeError: ExampleCommand must call success! or fail! and return the result
+        from ../chief/lib/chief/command.rb:9:in `call'
+        from (irb):6
+        from bin/console:14:in `<main>'
+```
+
+
 
 
 ## Installation

--- a/lib/chief/command.rb
+++ b/lib/chief/command.rb
@@ -1,7 +1,13 @@
 module Chief
   class Command
     def self.call(*args, &block)
-      new(*args, &block).call
+      instance = new(*args, &block)
+      result = instance.call
+      if result.is_a?(Chief::Result) && instance.send(:created_result_object)
+        result
+      else
+        fail "#{method(__method__).receiver} must call success! or fail! and return the result"
+      end
     end
 
     def self.value(*args)
@@ -13,10 +19,19 @@ module Chief
     end
 
     def success!(value = true)
-      Result.new(value, nil)
+      create_result_object(value, nil)
     end
 
     def fail!(value = false, errors = true)
+      create_result_object(value, errors)
+    end
+
+    private
+
+    attr_reader :created_result_object
+
+    def create_result_object(value, errors)
+      @created_result_object = true
       Result.new(value, errors)
     end
   end

--- a/spec/chief/integration_spec.rb
+++ b/spec/chief/integration_spec.rb
@@ -25,7 +25,31 @@ module Chief
     end
   end
 
+  class ExampleWithoutChiefResultCommand < Command
+    def call
+      :some_value
+    end
+  end
+
+  class ExampleWithChiefResultPassThroughCommand < Command
+    def call
+      ExampleFailingCommand.call(:some_value)
+    end
+  end
+
   RSpec.describe Command do
+    describe "Commands that don't return a Chief::Result object" do
+      it 'should raise an error' do
+        expect { ExampleWithoutChiefResultCommand.call }.to raise_error(RuntimeError)
+      end
+    end
+
+    describe 'Commands that pass through a different commands Chief::Result object' do
+      it 'should raise an error' do
+        expect { ExampleWithChiefResultPassThroughCommand.call }.to raise_error(RuntimeError, /ExampleWithChiefResultPassThroughCommand/)
+      end
+    end
+
     describe 'Commands that execute successfully' do
       it 'returns a success result object' do
         result = ExampleSuccessfulCommand.call(:some_value)


### PR DESCRIPTION
After some discussion we think it is best practice to return a
`Chief::Result` object from all `Chief::Command`s. We think this will lead
to easier to reason about code.

An example:

```ruby
class Example < Chief::Command
  def call
    some_other_chief_command
  end

  private

  def some_other_chief_command
    Command::DoSomething.call
  end
end
```

Code like this leads to a few questions:
- Do we not care about `some_other_chief_command` failing?
- Did we forget to to handle the `some_other_chief_command` fail case?
- Is the caller handling the `some_other_chief_command` error?
- Is the caller doing something with `some_other_chief_commands` value?

By enforcing every `Chief::Command` to call `success!` or `fail!` we can
force the developer to think about all of those questions and we can
help the future developer better understand the command.