### PR TITLE
Allow Chief::Result to be created without explicitly passing a nil error

### DIFF
--- a/lib/chief/result.rb
+++ b/lib/chief/result.rb
@@ -2,7 +2,7 @@ module Chief
   class Result
     attr_reader :value, :errors
 
-    def initialize(value, errors)
+    def initialize(value, errors = nil)
       @value = value
       @errors = errors
     end

--- a/spec/chief/result_spec.rb
+++ b/spec/chief/result_spec.rb
@@ -44,6 +44,13 @@ module Chief
           expect(result.success?).to be_truthy
         end
       end
+
+      context 'when the Result is not given an error' do
+        it 'returns true' do
+          result = Result.new(some_value)
+          expect(result.success?).to be_truthy
+        end
+      end
     end
 
     describe '#value' do


### PR DESCRIPTION
There are times when I want to create `Chief::Result` objects outside of
`Chief::Command`s (like in tests) and I don't want to pass `nil` for
every successful result. I think it is reasonable to default errors to
`nil`.